### PR TITLE
Use cases for edit, undo and redo commands

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -836,6 +836,46 @@ Use case ends.
 Use case resumes at step 2.
 
 [discrete]
+=== Use case: Edit a person's details
+
+*MSS*
+
+1. User requests to list persons
+2. AddressBook shows a list of persons
+3. User requests to edit the details of a specific person in the list
+4. AddressBook updates details of the specified person
++
+Use case ends.
+
+*Extensions*
+
+[none]
+* 2a. The list is empty.
++
+Use case ends.
+
+* 3a. The given index is invalid.
++
+[none]
+** 3a1. AddressBook shows an error message.
++
+Use case resumes at step 2.
+
+* 3b. User does not specify field to edit.
++
+[none]
+** 3b1. AddressBook shows an error message.
++
+Use case resumes at step 2.
+
+* 3c. User updates valid field with new value that is invalid.
++
+[none]
+** 3c1. AddressBook shows an error message.
++
+Use case resumes at step 2.
+
+[discrete]
 === Use case: Undo last undoable command
 
 *MSS*

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -800,6 +800,32 @@ Use case resumes at step 1.
 +
 Use case ends.
 
+[discrete]
+=== Use case: Redo last successful undo
+
+*MSS*
+
+1. User requests to redo the last undo
+2. AddressBook confirms if user really wishes to redo last undo
+3. User confirms the redo
+4. AddressBook redoes the last undo
++
+Use case ends.
+
+*Extensions*
+
+[none]
+* 3a. User cancels the redo.
++
+Use case ends.
+
+* 4a. The last successful command is not `undo`.
++
+[none]
+** 4a1. AddressBook shows an error message.
++
+Use case ends.
+
 {More to be added}
 
 [appendix]

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -786,29 +786,22 @@ Use case ends.
 +
 Use case ends.
 
-* 4a. There is no last command (i.e. the `undo` command is the first command)
+* 4a. The last command is undoable (i.e. a command that does not modify AddressBook's content)
 +
 [none]
 ** 4a1. AddressBook shows an error message.
 +
-Use case resumes at step 1.
-
-* 4b. The last command is also `undo`
-+
-[none]
-** 4b1. AddressBook shows an error message, and recommends useing `redo`.
-+
 Use case ends.
 
 [discrete]
-=== Use case: Redo last successful undo
+=== Use case: Redo most recently undone command
 
 *MSS*
 
-1. User requests to redo the last undo
-2. AddressBook confirms if user really wishes to redo last undo
+1. User requests a redo of the most recently undone command
+2. AddressBook confirms if user really wishes to redo
 3. User confirms the redo
-4. AddressBook redoes the last undo
+4. AddressBook redoes the last command
 +
 Use case ends.
 
@@ -819,7 +812,7 @@ Use case ends.
 +
 Use case ends.
 
-* 4a. The last successful command is not `undo`.
+* 4a. There are no `undo` commands executed previously
 +
 [none]
 ** 4a1. AddressBook shows an error message.

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -767,6 +767,39 @@ Use case ends.
 +
 Use case resumes at step 2.
 
+[discrete]
+=== Use case: Undo last command
+
+*MSS*
+
+1. User requests to undo last command
+2. AddressBook confirms if user really wishes to undo last command
+3. User confirms the undo
+4. AddressBook undoes the last command
++
+Use case ends.
+
+*Extensions*
+
+[none]
+* 3a. User cancels the undo.
++
+Use case ends.
+
+* 4a. There is no last command (i.e. the `undo` command is the first command)
++
+[none]
+** 4a1. AddressBook shows an error message.
++
+Use case resumes at step 1.
+
+* 4b. The last command is also `undo`
++
+[none]
+** 4b1. AddressBook shows an error message, and recommends useing `redo`.
++
+Use case ends.
+
 {More to be added}
 
 [appendix]

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -836,54 +836,42 @@ Use case ends.
 Use case resumes at step 2.
 
 [discrete]
-=== Use case: Undo last command
+=== Use case: Undo last undoable command
 
 *MSS*
 
-1. User requests to undo last command
-2. AddressBook confirms if user really wishes to undo last command
-3. User confirms the undo
-4. AddressBook undoes the last command
+1. User requests to undo last undoable command
+2. AddressBook undoes the last undoable command
 +
 Use case ends.
 
 *Extensions*
 
 [none]
-* 3a. User cancels the undo.
-+
-Use case ends.
-
-* 4a. The last command is undoable (i.e. a command that does not modify AddressBook's content)
+* 3a. The `undo` command is the first command.
 +
 [none]
-** 4a1. AddressBook shows an error message.
+** 3a1. AddressBook shows an error message.
 +
 Use case ends.
 
 [discrete]
-=== Use case: Redo most recently undone command
+=== Use case: Redo most recent undone command
 
 *MSS*
 
-1. User requests a redo of the most recently undone command
-2. AddressBook confirms if user really wishes to redo
-3. User confirms the redo
-4. AddressBook redoes the last command
+1. User requests to redo most recently undone command
+2. AddressBook redoes the last undone command
 +
 Use case ends.
 
 *Extensions*
 
 [none]
-* 3a. User cancels the redo.
-+
-Use case ends.
-
-* 4a. There are no `undo` commands executed previously
+* 3a. The `redo` command is the first command
 +
 [none]
-** 4a1. AddressBook shows an error message.
+** 3a1. AddressBook shows an error message.
 +
 Use case ends.
 


### PR DESCRIPTION
I have added use cases for `edit`, `undo` and `redo` commands. This is because the use cases for `undo` and `redo` commands are somewhat trivial, so I decided to add for `edit` as well since `edit` is an `UndoableCommand` that is related to `undo` and `redo`.

P/S Opened a new PR because I experimented with branch renaming, and realised that the old branch was deleted along the way...which consequently closed the old PR automatically.