### PR TITLE
Update documentation links to point to team repository

### DIFF
--- a/docs/ContactUs.adoc
+++ b/docs/ContactUs.adoc
@@ -1,6 +1,6 @@
 = Contact Us
 :stylesDir: stylesheets
 
-* *Bug reports, Suggestions* : Post in our https://github.com/se-edu/addressbook-level4/issues[issue tracker] if you noticed bugs or have suggestions on how to improve.
+* *Bug reports, Suggestions* : Post in our https://github.com/CS2103AUG2017-F10-B1/main/issues[issue tracker] if you noticed bugs or have suggestions on how to improve.
 * *Contributing* : We welcome pull requests. Follow the process described https://github.com/oss-generic/process[here]
 * *Email us* : You can also reach us at `damith [at] comp.nus.edu.sg`

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -10,7 +10,7 @@ ifdef::env-github[]
 :note-caption: :information_source:
 endif::[]
 ifdef::env-github,env-browser[:outfilesuffix: .adoc]
-:repoURL: https://github.com/se-edu/addressbook-level4/tree/master
+:repoURL: https://github.com/CS2103AUG2017-F10-B1/main
 
 By: `Team SE-EDU`      Since: `Jun 2016`      Licence: `MIT`
 

--- a/docs/LearningOutcomes.adoc
+++ b/docs/LearningOutcomes.adoc
@@ -7,7 +7,7 @@
 :imagesDir: images
 :stylesDir: stylesheets
 ifdef::env-github,env-browser[:outfilesuffix: .adoc]
-:repoURL: https://github.com/se-edu/addressbook-level4/tree/master
+:repoURL: https://github.com/CS2103AUG2017-F10-B1/main
 
 After studying this code and completing the corresponding exercises, you should be able to,
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -10,7 +10,7 @@ ifdef::env-github[]
 :tip-caption: :bulb:
 :note-caption: :information_source:
 endif::[]
-:repoURL: https://github.com/se-edu/addressbook-level4
+:repoURL: https://github.com/CS2103AUG2017-F10-B1/main
 
 By: `Team SE-EDU`      Since: `Jun 2016`      Licence: `MIT`
 


### PR DESCRIPTION
The `repoURL` in `ContactUs.adoc`, `DeveloperGuide.adoc`, `LearningOutcomes.adoc` and `UserGuide.adoc` have been updated to our team's repository link instead of `se-edu`. 