### PR TITLE
Implement enhanced find command

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -93,25 +93,113 @@ Edits the phone number and email address of the 1st person to be `91234567` and 
 * `edit 2 n/Betsy Crower t/` +
 Edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
 
-=== Locating persons by name: `find`
+=== Locating persons: `find`
 
-Finds persons whose names contain any of the given keywords. +
+Finds persons whose details contain any of the given keywords. +
 Format: `find KEYWORD [MORE_KEYWORDS]`
 
 ****
 * The search is case insensitive. e.g `hans` will match `Hans`
 * The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
-* Only the name is searched.
-* Only full words will be matched e.g. `Han` will not match `Hans`
+* The search works even in the presence of whitespaces
+* All details, including names, addresses, emails, phones and tags are searched
+* Partial words will also be matched e.g. `Han` will match `Hans`
 * Persons matching at least one keyword will be returned (i.e. `OR` search). e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
+* If a prefix is specified, the scope of the search will be narrowed to a particular detail set (see sections below)
+* If more than one type of prefix is specified, the search will be treated as an invalid search
 ****
 
 Examples:
 
 * `find John` +
 Returns `john` and `John Doe`
+* `find Jo` +
+Returns `john` and `John Doe`
 * `find Betsy Tim John` +
+Returns any person having names or email addresses containing `Betsy`, `Tim`, or `John`
+* `find 92334266` +
+Returns any person having phone number/email address/address containing `92334266`
+* `find Alice 92334266` +
+Returns any person having name `Alice` AND/OR having phone number/email address/address containing `92334266`
+
+==== Locating persons by name: `find n/`
+
+Finds persons whose names contain any of the given keywords. +
+Format: `find n/[KEYWORDS]`
+
+Examples:
+
+* `find n/John` +
+Returns `john` and `John Doe`
+* `find n/Jo` +
+Returns `john` and `John Doe`
+* `find n/Betsy Tim John` +
 Returns any person having names `Betsy`, `Tim`, or `John`
+
+[TIP]
+You can find multiple persons with a single name search
+
+==== Locating persons by address: `find a/`
+
+Finds persons whose addresses contain any of the given keywords. +
+Format: `find a/[KEYWORDS]`
+
+Examples:
+
+* `find a/Serangoon` +
+Returns any persons having addresses in Serangoon
+* `find a/seRangOOn` +
+Returns any persons having addresses in Serangoon
+* `find a/Ser` +
+Returns any persons having addresses containing the phrase `Ser`
+* `find a/Serangoon Gardens` +
+Returns any person having addresses containing the phrase `Serangoon` AND/OR `Gardens`
+
+==== Locating persons by email: `find e/`
+
+Finds persons whose emails contain any of the given keywords. +
+Format: `find e/[KEYWORDS]`
+
+Examples:
+
+* `find e/alice@example.com` +
+Returns `Alice`
+* `find e/AliCE@ExaMPle.com` +
+Returns `Alice`
+* `find e/@example.com` +
+Returns any persons having email addresses containing the suffix `@example.com`
+* `find e/@example.com @yahoo.com` +
+Returns any person having email addresses containing the suffix `@example.com` or `@yahoo.com`
+
+==== Locating persons by phone: `find p/`
+
+Finds persons whose phone numbers contain any of the given keywords. +
+Format: `find p/[KEYWORDS]`
+
+Examples:
+
+* `find p/97734225` +
+Returns any persons having phone numbers matching `97734225`
+* `find p/9773` +
+Returns any persons having phone numbers containing the sequence `9773`
+* `find p/97734225 90329038` +
+Returns any persons having phone numbers matching `97734225` OR `90329038`
+
+==== Locating persons by tag: `find t/`
+
+Finds persons whose tags contain any of the given keywords. +
+Format: `find t/[KEYWORDS]`
+
+Examples:
+
+* `find t/friends` +
+Returns any persons having tags matching `friends`
+* `find t/FriEndS` +
+Returns any persons having tags matching `friends`
+* `find t/frIe` +
+Returns any persons having tags containing the phrase `frie`
+* `find t/friends family` +
+Returns any persons having tags matching `friends` AND/OR `family`
 
 === Deleting a person : `delete`
 

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -13,11 +13,12 @@ public class StringUtil {
 
     /**
      * Returns true if the {@code sentence} contains the {@code word}.
-     *   Ignores case, but a full word match is required.
+     *   Ignores case, and a full word match is not required.
      *   <br>examples:<pre>
      *       containsWordIgnoreCase("ABc def", "abc") == true
      *       containsWordIgnoreCase("ABc def", "DEF") == true
-     *       containsWordIgnoreCase("ABc def", "AB") == false //not a full word match
+     *       containsWordIgnoreCase("ABc def", "AB") == true //even though it is not a full word match
+     *       containsWordIgnoreCase("ABc def", "xyz") == false //no matches
      *       </pre>
      * @param sentence cannot be null
      * @param word cannot be null, cannot be empty, must be a single word
@@ -34,7 +35,7 @@ public class StringUtil {
         String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
 
         for (String wordInSentence: wordsInPreppedSentence) {
-            if (wordInSentence.equalsIgnoreCase(preppedWord)) {
+            if (wordInSentence.toLowerCase().contains(preppedWord.toLowerCase())) {
                 return true;
             }
         }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,24 +1,37 @@
 package seedu.address.logic.commands;
 
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import java.util.function.Predicate;
+
+import seedu.address.model.person.ReadOnlyPerson;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
+ * Finds and lists all persons in address book whose details contain any of the argument keywords.
  * Keyword matching is case sensitive.
+ *
+ * If a prefix is specified, finds and lists all persons in address book whose detail corresponding to the prefix
+ * matches the argument keywords.
  */
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
     public static final String COMMAND_ALIAS = "f";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose details contain any of "
             + "the specified keywords (case-sensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "A prefix can also be specified to narrow the search to persons whose particular detail contains any of "
+            + "the keywords (case-sensitive).\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]... or KEYWORD [PREFIX]/[MORE_KEYWORDS]...\n"
+            + "Examples:\n"
+            + COMMAND_WORD + " alice Serangoon\n"
+            + COMMAND_WORD + " n/alice bob\n"
+            + COMMAND_WORD + " a/Serangoon\n"
+            + COMMAND_WORD + " e/bob@example.com\n"
+            + COMMAND_WORD + " p/96779802\n"
+            + COMMAND_WORD + " t/friends";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final Predicate<ReadOnlyPerson> predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCommand(Predicate<ReadOnlyPerson> predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.parser;
 
+import java.util.HashMap;
+
 /**
  * Contains Command Line Interface (CLI) syntax definitions common to multiple commands
  */
@@ -11,5 +13,16 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+
+    /* Prefix mappings */
+    public static final HashMap<String, Prefix> PREFIX_MAPPING;
+    static {
+        PREFIX_MAPPING = new HashMap<>();
+        PREFIX_MAPPING.put("n/", PREFIX_NAME);
+        PREFIX_MAPPING.put("a/", PREFIX_ADDRESS);
+        PREFIX_MAPPING.put("e/", PREFIX_EMAIL);
+        PREFIX_MAPPING.put("p/", PREFIX_PHONE);
+        PREFIX_MAPPING.put("t/", PREFIX_TAG);
+    }
 
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -3,13 +3,13 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MAPPING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -79,13 +79,13 @@ public class FindCommandParser implements Parser<FindCommand> {
             List<String> address = argMultimap.getAllValues(PREFIX_ADDRESS);
             List<String> trimmedAddress = prepareArguments(address);
             predicate = new AddressContainsKeywordsPredicate(trimmedAddress);
-        } else if (targetPrefix.equals(PREFIX_TAG)) {
+        } else {
             List<String> tagList = argMultimap.getAllValues(PREFIX_TAG);
             List<String> trimmedTagList = prepareArguments(tagList);
             predicate = new TagContainsKeywordsPredicate(trimmedTagList);
-        } else {
-            throw new ParseException("Something bad has happened during parsing. Please contact the project team!");
         }
+        assert(PREFIX_MAPPING.containsValue(targetPrefix));
+
         return new FindCommand(predicate);
     }
 
@@ -94,15 +94,8 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @param args
      */
     private static List<Prefix> getPrefixes(String args) {
-        HashMap<String, Prefix> prefixMapping = new HashMap<>();
-        prefixMapping.put("n/", PREFIX_NAME);
-        prefixMapping.put("a/", PREFIX_ADDRESS);
-        prefixMapping.put("e/", PREFIX_EMAIL);
-        prefixMapping.put("p/", PREFIX_PHONE);
-        prefixMapping.put("t/", PREFIX_TAG);
         List<Prefix> prefixesInList = new ArrayList<>();
-
-        for (Map.Entry<String, Prefix> entry : prefixMapping.entrySet()) {
+        for (Map.Entry<String, Prefix> entry : PREFIX_MAPPING.entrySet()) {
             if (args.contains(entry.getKey())) {
                 prefixesInList.add(entry.getValue());
             }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,12 +1,28 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.AddressContainsKeywordsPredicate;
+import seedu.address.model.person.AnyContainsKeywordsPredicate;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.model.tag.TagContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -19,15 +35,113 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
+        Predicate<ReadOnlyPerson> predicate;
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        List<Prefix> getPrefixInArgs = getPrefixes(trimmedArgs);
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        if (getPrefixInArgs.isEmpty()) {
+            List<String> arguments = Arrays.asList(trimmedArgs.split(" "));
+            List<String> trimmedArguments = prepareArguments(arguments);
+            return new FindCommand(new AnyContainsKeywordsPredicate(trimmedArguments));
+        }
+
+        if (getPrefixInArgs.size() > 1) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+
+        Prefix targetPrefix = getPrefixInArgs.get(0);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, targetPrefix);
+
+        if (!isAPrefixWithValue(argMultimap, targetPrefix)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+
+        if (targetPrefix.equals(PREFIX_NAME)) {
+            List<String> name = argMultimap.getAllValues(PREFIX_NAME);
+            List<String> trimmedName = prepareArguments(name);
+            predicate = new NameContainsKeywordsPredicate(trimmedName);
+        } else if (targetPrefix.equals(PREFIX_PHONE)) {
+            List<String> phone = argMultimap.getAllValues(PREFIX_PHONE);
+            List<String> trimmedPhone = prepareArguments(phone);
+            predicate = new PhoneContainsKeywordsPredicate(trimmedPhone);
+        } else if (targetPrefix.equals(PREFIX_EMAIL)) {
+            List<String> email = argMultimap.getAllValues(PREFIX_EMAIL);
+            List<String> trimmedEmail = prepareArguments(email);
+            predicate = new EmailContainsKeywordsPredicate(trimmedEmail);
+        } else if (targetPrefix.equals(PREFIX_ADDRESS)) {
+            List<String> address = argMultimap.getAllValues(PREFIX_ADDRESS);
+            List<String> trimmedAddress = prepareArguments(address);
+            predicate = new AddressContainsKeywordsPredicate(trimmedAddress);
+        } else if (targetPrefix.equals(PREFIX_TAG)) {
+            List<String> tagList = argMultimap.getAllValues(PREFIX_TAG);
+            List<String> trimmedTagList = prepareArguments(tagList);
+            predicate = new TagContainsKeywordsPredicate(trimmedTagList);
+        } else {
+            throw new ParseException("Something bad has happened during parsing. Please contact the project team!");
+        }
+        return new FindCommand(predicate);
+    }
+
+    /**
+     * Returns a list of prefixes that can be found in the arguments list.
+     * @param args
+     */
+    private static List<Prefix> getPrefixes(String args) {
+        HashMap<String, Prefix> prefixMapping = new HashMap<>();
+        prefixMapping.put("n/", PREFIX_NAME);
+        prefixMapping.put("a/", PREFIX_ADDRESS);
+        prefixMapping.put("e/", PREFIX_EMAIL);
+        prefixMapping.put("p/", PREFIX_PHONE);
+        prefixMapping.put("t/", PREFIX_TAG);
+        List<Prefix> prefixesInList = new ArrayList<>();
+
+        for (Map.Entry<String, Prefix> entry : prefixMapping.entrySet()) {
+            if (args.contains(entry.getKey())) {
+                prefixesInList.add(entry.getValue());
+            }
+        }
+        return prefixesInList;
+    }
+
+    /**
+     * Prepares the argument list to be searched by ensuring that each argument is a single word without
+     * any leading or ending whitespaces.
+     * @param potentialArgumentsList
+     */
+    private static List<String> prepareArguments(List<String> potentialArgumentsList) {
+        List<String> preparedArgumentsList = new ArrayList<>();
+        for (String arg : potentialArgumentsList) {
+            String[] element = arg.split(" ");
+            for (String subElement : element) {
+                String trimmedSubElement = subElement.trim();
+                if (!trimmedSubElement.isEmpty()) {
+                    preparedArgumentsList.add(trimmedSubElement);
+                }
+            }
+        }
+        return preparedArgumentsList;
+    }
+
+    /**
+     * Returns true if the target prefix contains at least one non-empty {@code Optional} value in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean isAPrefixWithValue(ArgumentMultimap argumentMultimap, Prefix prefix) {
+        List<String> values = argumentMultimap.getAllValues(prefix);
+        boolean hasValue = false;
+        for (String v : values) {
+            if (!v.isEmpty()) {
+                hasValue = true;
+            }
+        }
+        return hasValue;
     }
 
 }

--- a/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code ReadOnlyPerson}'s {@code Address} matches any of the keywords given.
+ */
+public class AddressContainsKeywordsPredicate implements Predicate<ReadOnlyPerson> {
+    private final List<String> keywords;
+
+    public AddressContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(ReadOnlyPerson person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getAddress().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddressContainsKeywordsPredicate // instanceof handles nulls
+                && this.keywords.equals(((AddressContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/AnyContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AnyContainsKeywordsPredicate.java
@@ -3,9 +3,9 @@ package seedu.address.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
-
 import com.google.common.base.Joiner;
+
+import seedu.address.commons.util.StringUtil;
 
 /**
  * Tests that a {@code ReadOnlyPerson}'s details matches any of the keywords given.
@@ -22,11 +22,11 @@ public class AnyContainsKeywordsPredicate implements Predicate<ReadOnlyPerson> {
         String stringifyTags = Joiner.on(" ").join(person.getTags());
 
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword) ||
-                        StringUtil.containsWordIgnoreCase(person.getAddress().value, keyword) ||
-                        StringUtil.containsWordIgnoreCase(person.getEmail().value, keyword) ||
-                        StringUtil.containsWordIgnoreCase(person.getPhone().value, keyword) ||
-                        StringUtil.containsWordIgnoreCase(stringifyTags, keyword)
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword)
+                        || StringUtil.containsWordIgnoreCase(person.getAddress().value, keyword)
+                        || StringUtil.containsWordIgnoreCase(person.getEmail().value, keyword)
+                        || StringUtil.containsWordIgnoreCase(person.getPhone().value, keyword)
+                        || StringUtil.containsWordIgnoreCase(stringifyTags, keyword)
                 );
     }
 

--- a/src/main/java/seedu/address/model/person/AnyContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AnyContainsKeywordsPredicate.java
@@ -1,0 +1,40 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+import com.google.common.base.Joiner;
+
+/**
+ * Tests that a {@code ReadOnlyPerson}'s details matches any of the keywords given.
+ */
+public class AnyContainsKeywordsPredicate implements Predicate<ReadOnlyPerson> {
+    private final List<String> keywords;
+
+    public AnyContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(ReadOnlyPerson person) {
+        String stringifyTags = Joiner.on(" ").join(person.getTags());
+
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword) ||
+                        StringUtil.containsWordIgnoreCase(person.getAddress().value, keyword) ||
+                        StringUtil.containsWordIgnoreCase(person.getEmail().value, keyword) ||
+                        StringUtil.containsWordIgnoreCase(person.getPhone().value, keyword) ||
+                        StringUtil.containsWordIgnoreCase(stringifyTags, keyword)
+                );
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AnyContainsKeywordsPredicate // instanceof handles nulls
+                && this.keywords.equals(((AnyContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code ReadOnlyPerson}'s {@code Email} matches any of the keywords given.
+ */
+public class EmailContainsKeywordsPredicate implements Predicate<ReadOnlyPerson> {
+    private final List<String> keywords;
+
+    public EmailContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(ReadOnlyPerson person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getEmail().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof EmailContainsKeywordsPredicate // instanceof handles nulls
+                && this.keywords.equals(((EmailContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code ReadOnlyPerson}'s {@code Phone} matches any of the keywords given.
+ */
+public class PhoneContainsKeywordsPredicate implements Predicate<ReadOnlyPerson> {
+    private final List<String> keywords;
+
+    public PhoneContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(ReadOnlyPerson person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getPhone().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PhoneContainsKeywordsPredicate // instanceof handles nulls
+                && this.keywords.equals(((PhoneContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
@@ -3,8 +3,6 @@ package seedu.address.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
-
 /**
  * Tests that a {@code ReadOnlyPerson}'s {@code Phone} matches any of the keywords given.
  */
@@ -18,7 +16,7 @@ public class PhoneContainsKeywordsPredicate implements Predicate<ReadOnlyPerson>
     @Override
     public boolean test(ReadOnlyPerson person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getPhone().value, keyword));
+                .anyMatch(keyword -> (person.getPhone().value.contains(keyword)));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/tag/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/tag/TagContainsKeywordsPredicate.java
@@ -3,10 +3,10 @@ package seedu.address.model.tag;
 import java.util.List;
 import java.util.function.Predicate;
 
+import com.google.common.base.Joiner;
+
 import seedu.address.commons.util.StringUtil;
 import seedu.address.model.person.ReadOnlyPerson;
-
-import com.google.common.base.Joiner;
 
 /**
  * Tests that a {@code ReadOnlyPerson}'s {@code Tag} matches any of the keywords given.

--- a/src/main/java/seedu/address/model/tag/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/tag/TagContainsKeywordsPredicate.java
@@ -1,0 +1,35 @@
+package seedu.address.model.tag;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.model.person.ReadOnlyPerson;
+
+import com.google.common.base.Joiner;
+
+/**
+ * Tests that a {@code ReadOnlyPerson}'s {@code Tag} matches any of the keywords given.
+ */
+public class TagContainsKeywordsPredicate implements Predicate<ReadOnlyPerson> {
+    private final List<String> keywords;
+
+    public TagContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(ReadOnlyPerson person) {
+        String stringifyTags = Joiner.on(" ").join(person.getTags());
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(stringifyTags, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TagContainsKeywordsPredicate // instanceof handles nulls
+                && this.keywords.equals(((TagContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -107,9 +107,10 @@ public class StringUtilTest {
      *   - last word in sentence
      *   - middle word in sentence
      *   - matches multiple words
+     *   - query word matches part of a sentence word
      *
      * Possible scenarios returning false:
-     *   - query word matches part of a sentence word
+     *   - query word does not match any sentence word
      *   - sentence word matches part of the query word
      *
      * The test method below tries to verify all above with a reasonably low number of test cases.
@@ -122,8 +123,10 @@ public class StringUtilTest {
         assertFalse(StringUtil.containsWordIgnoreCase("", "abc")); // Boundary case
         assertFalse(StringUtil.containsWordIgnoreCase("    ", "123"));
 
-        // Matches a partial word only
-        assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bb")); // Sentence word bigger than query word
+        // Matches a partial word where sentence word is bigger than query word
+        assertTrue(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bb")); // Sentence word bigger than query word
+
+        // Matches a partial word where query word is bigger than sentence word
         assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bbbb")); // Query word bigger than sentence word
 
         // Matches word in the sentence, different upper/lower case letters
@@ -135,6 +138,9 @@ public class StringUtilTest {
 
         // Matches multiple words in sentence
         assertTrue(StringUtil.containsWordIgnoreCase("AAA bBb ccc  bbb", "bbB"));
+
+        // No matches between query word and sentence
+        assertFalse(StringUtil.containsWordIgnoreCase("AAA bBb ccc", "xyz"));
     }
 
     //---------------- Tests for getDetails --------------------------------------

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -4,9 +4,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
+import static seedu.address.testutil.TypicalPersons.GEORGE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
@@ -21,8 +25,13 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.AddressContainsKeywordsPredicate;
+import seedu.address.model.person.AnyContainsKeywordsPredicate;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.model.tag.TagContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -32,51 +41,245 @@ public class FindCommandTest {
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+        AnyContainsKeywordsPredicate firstPredicate =
+                new AnyContainsKeywordsPredicate(Collections.singletonList("first"));
+        AnyContainsKeywordsPredicate secondPredicate =
+                new AnyContainsKeywordsPredicate(Collections.singletonList("second"));
+        NameContainsKeywordsPredicate thirdPredicate =
+                new NameContainsKeywordsPredicate(Collections.singletonList("third"));
+        NameContainsKeywordsPredicate fourthPredicate =
+                new NameContainsKeywordsPredicate(Collections.singletonList("fourth"));
+        AddressContainsKeywordsPredicate fifthPredicate =
+                new AddressContainsKeywordsPredicate(Collections.singletonList("fifth"));
+        AddressContainsKeywordsPredicate sixthPredicate =
+                new AddressContainsKeywordsPredicate(Collections.singletonList("sixth"));
+        EmailContainsKeywordsPredicate seventhPredicate =
+                new EmailContainsKeywordsPredicate(Collections.singletonList("seventh"));
+        EmailContainsKeywordsPredicate eighthPredicate =
+                new EmailContainsKeywordsPredicate(Collections.singletonList("eighth"));
+        PhoneContainsKeywordsPredicate ninthPredicate =
+                new PhoneContainsKeywordsPredicate(Collections.singletonList("ninth"));
+        PhoneContainsKeywordsPredicate tenthPredicate =
+                new PhoneContainsKeywordsPredicate(Collections.singletonList("tenth"));
+        TagContainsKeywordsPredicate eleventhPredicate =
+                new TagContainsKeywordsPredicate(Collections.singletonList("eleventh"));
+        TagContainsKeywordsPredicate twelfthPredicate =
+                new TagContainsKeywordsPredicate(Collections.singletonList("twelfth"));
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);
         FindCommand findSecondCommand = new FindCommand(secondPredicate);
+        FindCommand findThirdCommand = new FindCommand(thirdPredicate);
+        FindCommand findFourthCommand = new FindCommand(fourthPredicate);
+        FindCommand findFifthCommand = new FindCommand(fifthPredicate);
+        FindCommand findSixthCommand = new FindCommand(sixthPredicate);
+        FindCommand findSeventhCommand = new FindCommand(seventhPredicate);
+        FindCommand findEighthCommand = new FindCommand(eighthPredicate);
+        FindCommand findNinthCommand = new FindCommand(ninthPredicate);
+        FindCommand findTenthCommand = new FindCommand(tenthPredicate);
+        FindCommand findEleventhCommand = new FindCommand(eleventhPredicate);
+        FindCommand findTwelfthCommand = new FindCommand(twelfthPredicate);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
+        assertTrue(findThirdCommand.equals(findThirdCommand));
+        assertTrue(findFifthCommand.equals(findFifthCommand));
+        assertTrue(findSeventhCommand.equals(findSeventhCommand));
+        assertTrue(findNinthCommand.equals(findNinthCommand));
+        assertTrue(findEleventhCommand.equals(findEleventhCommand));
 
         // same values -> returns true
         FindCommand findFirstCommandCopy = new FindCommand(firstPredicate);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+        FindCommand findThirdCommandCopy = new FindCommand(thirdPredicate);
+        assertTrue(findThirdCommand.equals(findThirdCommandCopy));
+        FindCommand findFifthCommandCopy = new FindCommand(fifthPredicate);
+        assertTrue(findFifthCommand.equals(findFifthCommandCopy));
+        FindCommand findSeventhCommandCopy = new FindCommand(seventhPredicate);
+        assertTrue(findSeventhCommand.equals(findSeventhCommandCopy));
+        FindCommand findNinthCommandCopy = new FindCommand(ninthPredicate);
+        assertTrue(findNinthCommand.equals(findNinthCommandCopy));
+        FindCommand findEleventhCommandCopy = new FindCommand(eleventhPredicate);
+        assertTrue(findEleventhCommand.equals(findEleventhCommandCopy));
 
         // different types -> returns false
         assertFalse(findFirstCommand.equals(1));
+        assertFalse(findThirdCommand.equals(1));
+        assertFalse(findFifthCommand.equals(1));
+        assertFalse(findSeventhCommand.equals(1));
+        assertFalse(findNinthCommand.equals(1));
+        assertFalse(findEleventhCommand.equals(1));
 
         // null -> returns false
         assertFalse(findFirstCommand.equals(null));
+        assertFalse(findThirdCommand.equals(null));
+        assertFalse(findFifthCommand.equals(null));
+        assertFalse(findSeventhCommand.equals(null));
+        assertFalse(findNinthCommand.equals(null));
+        assertFalse(findEleventhCommand.equals(null));
 
         // different person -> returns false
         assertFalse(findFirstCommand.equals(findSecondCommand));
+        assertFalse(findThirdCommand.equals(findFourthCommand));
+        assertFalse(findFifthCommand.equals(findSixthCommand));
+        assertFalse(findSeventhCommand.equals(findEighthCommand));
+        assertFalse(findNinthCommand.equals(findTenthCommand));
+        assertFalse(findEleventhCommand.equals(findTwelfthCommand));
     }
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        FindCommand command = prepareCommand(" ");
+        String expectedMessage = expectedMessage(0);
+
+        FindCommand command = prepareGlobalCommand(" ");
         assertCommandSuccess(command, expectedMessage, Collections.emptyList());
+
+        FindCommand nameCommand = prepareNameCommand(" ");
+        assertCommandSuccess(nameCommand, expectedMessage, Collections.emptyList());
+
+        FindCommand addressCommand = prepareAddressCommand(" ");
+        assertCommandSuccess(addressCommand, expectedMessage, Collections.emptyList());
+
+        FindCommand emailCommand = prepareEmailCommand(" ");
+        assertCommandSuccess(emailCommand, expectedMessage, Collections.emptyList());
+
+        FindCommand phoneCommand = preparePhoneCommand(" ");
+        assertCommandSuccess(phoneCommand, expectedMessage, Collections.emptyList());
+
+        FindCommand tagCommand = prepareTagCommand(" ");
+        assertCommandSuccess(tagCommand, expectedMessage, Collections.emptyList());
+    }
+
+    @Test
+    public void execute_singleKeyword_onePersonFound() {
+        String expectedMessage = expectedMessage(1);
+
+        FindCommand command = prepareGlobalCommand("Kurz");
+        assertCommandSuccess(command, expectedMessage, Arrays.asList(CARL));
+
+        FindCommand nameCommand = prepareNameCommand("Elle");
+        assertCommandSuccess(nameCommand, expectedMessage, Arrays.asList(ELLE));
+
+        FindCommand addressCommand = prepareAddressCommand("10th");
+        assertCommandSuccess(addressCommand, expectedMessage, Arrays.asList(DANIEL));
+
+        FindCommand emailCommand = prepareEmailCommand("alice@example.com");
+        assertCommandSuccess(emailCommand, expectedMessage, Arrays.asList(ALICE));
+
+        FindCommand phoneCommand = preparePhoneCommand("948242");
+        assertCommandSuccess(phoneCommand, expectedMessage, Arrays.asList(FIONA));
+
+        FindCommand tagCommand = prepareTagCommand("owesMoney");
+        assertCommandSuccess(tagCommand, expectedMessage, Arrays.asList(BENSON));
+    }
+
+    @Test
+    public void execute_singleKeyword_multiplePersonsFound() {
+        FindCommand command = prepareGlobalCommand("Meier");
+        assertCommandSuccess(command, expectedMessage(2), Arrays.asList(BENSON, DANIEL));
+
+        FindCommand nameCommand = prepareNameCommand("Meier");
+        assertCommandSuccess(nameCommand, expectedMessage(2), Arrays.asList(BENSON, DANIEL));
+
+        FindCommand addressCommand = prepareAddressCommand("ave");
+        assertCommandSuccess(addressCommand, expectedMessage(3), Arrays.asList(ALICE, BENSON, ELLE));
+
+        FindCommand emailCommand = prepareEmailCommand("@example.com");
+        assertCommandSuccess(emailCommand, expectedMessage(7),
+                Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
+
+        FindCommand phoneCommand = preparePhoneCommand("94824");
+        assertCommandSuccess(phoneCommand, expectedMessage(2), Arrays.asList(FIONA, GEORGE));
+
+        FindCommand tagCommand = prepareTagCommand("friends");
+        assertCommandSuccess(tagCommand, expectedMessage(6),
+                Arrays.asList(ALICE, BENSON, DANIEL, ELLE, FIONA, GEORGE));
     }
 
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        FindCommand command = prepareCommand("Kurz Elle Kunz");
-        assertCommandSuccess(command, expectedMessage, Arrays.asList(CARL, ELLE, FIONA));
+        FindCommand command = prepareGlobalCommand("Kurz Elle Kunz");
+        assertCommandSuccess(command, expectedMessage(3), Arrays.asList(CARL, ELLE, FIONA));
+
+        FindCommand nameCommand = prepareNameCommand("Kurz Elle Kunz");
+        assertCommandSuccess(nameCommand, expectedMessage(3), Arrays.asList(CARL, ELLE, FIONA));
+
+        FindCommand addressCommand = prepareAddressCommand("ave 10");
+        assertCommandSuccess(addressCommand, expectedMessage(4), Arrays.asList(ALICE, BENSON, DANIEL, ELLE));
+
+        FindCommand emailCommand = prepareEmailCommand("alice anna");
+        assertCommandSuccess(emailCommand, expectedMessage(2), Arrays.asList(ALICE, GEORGE));
+
+        FindCommand phoneCommand = preparePhoneCommand("953  94824");
+        assertCommandSuccess(phoneCommand, expectedMessage(3), Arrays.asList(CARL, FIONA, GEORGE));
+
+        FindCommand tagCommand = prepareTagCommand("owesMoney enemy");
+        assertCommandSuccess(tagCommand, expectedMessage(2), Arrays.asList(BENSON, CARL));
     }
 
     /**
-     * Parses {@code userInput} into a {@code FindCommand}.
+     * Formats the expected message and changes the message according to the number of persons found.
+     * @param personsFound
      */
-    private FindCommand prepareCommand(String userInput) {
+    private String expectedMessage(int personsFound) {
+        return String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, personsFound);
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code FindCommand} for a global find.
+     */
+    private FindCommand prepareGlobalCommand(String userInput) {
+        FindCommand command =
+                new FindCommand(new AnyContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+"))));
+        command.setData(model, new CommandHistory(), new UndoRedoStack());
+        return command;
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code FindCommand} for a name search.
+     */
+    private FindCommand prepareNameCommand(String userInput) {
         FindCommand command =
                 new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+"))));
+        command.setData(model, new CommandHistory(), new UndoRedoStack());
+        return command;
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code FindCommand} for an address search.
+     */
+    private FindCommand prepareAddressCommand(String userInput) {
+        FindCommand command =
+                new FindCommand(new AddressContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+"))));
+        command.setData(model, new CommandHistory(), new UndoRedoStack());
+        return command;
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code FindCommand} for an email search.
+     */
+    private FindCommand prepareEmailCommand(String userInput) {
+        FindCommand command =
+                new FindCommand(new EmailContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+"))));
+        command.setData(model, new CommandHistory(), new UndoRedoStack());
+        return command;
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code FindCommand} for a phone search.
+     */
+    private FindCommand preparePhoneCommand(String userInput) {
+        FindCommand command =
+                new FindCommand(new PhoneContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+"))));
+        command.setData(model, new CommandHistory(), new UndoRedoStack());
+        return command;
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code FindCommand} for a tag search.
+     */
+    private FindCommand prepareTagCommand(String userInput) {
+        FindCommand command =
+                new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+"))));
         command.setData(model, new CommandHistory(), new UndoRedoStack());
         return command;
     }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -169,7 +169,7 @@ public class FindCommandTest {
         assertCommandSuccess(phoneCommand, expectedMessage, Arrays.asList(FIONA));
 
         FindCommand tagCommand = prepareTagCommand("owesMoney");
-        assertCommandSuccess(tagCommand, expectedMessage, Arrays.asList(BENSON));
+        assertCommandSuccess(tagCommand, expectedMessage(2), Arrays.asList(BENSON, FIONA));
     }
 
     @Test
@@ -191,8 +191,8 @@ public class FindCommandTest {
         assertCommandSuccess(phoneCommand, expectedMessage(2), Arrays.asList(FIONA, GEORGE));
 
         FindCommand tagCommand = prepareTagCommand("friends");
-        assertCommandSuccess(tagCommand, expectedMessage(6),
-                Arrays.asList(ALICE, BENSON, DANIEL, ELLE, FIONA, GEORGE));
+        assertCommandSuccess(tagCommand, expectedMessage(5),
+                Arrays.asList(ALICE, BENSON, CARL, DANIEL, GEORGE));
     }
 
     @Test
@@ -213,7 +213,7 @@ public class FindCommandTest {
         assertCommandSuccess(phoneCommand, expectedMessage(3), Arrays.asList(CARL, FIONA, GEORGE));
 
         FindCommand tagCommand = prepareTagCommand("owesMoney enemy");
-        assertCommandSuccess(tagCommand, expectedMessage(2), Arrays.asList(BENSON, CARL));
+        assertCommandSuccess(tagCommand, expectedMessage(3), Arrays.asList(BENSON, CARL, FIONA));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -29,8 +29,13 @@ import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.AddressContainsKeywordsPredicate;
+import seedu.address.model.person.AnyContainsKeywordsPredicate;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+import seedu.address.model.tag.TagContainsKeywordsPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -81,7 +86,27 @@ public class AddressBookParserTest {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+        assertEquals(new FindCommand(new AnyContainsKeywordsPredicate(keywords)), command);
+
+        FindCommand nameCommand = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " n/" + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), nameCommand);
+
+        FindCommand addressCommand = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " a/" + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(new AddressContainsKeywordsPredicate(keywords)), addressCommand);
+
+        FindCommand emailCommand = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " e/" + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(new EmailContainsKeywordsPredicate(keywords)), emailCommand);
+
+        FindCommand phoneCommand = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " p/" + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(new PhoneContainsKeywordsPredicate(keywords)), phoneCommand);
+
+        FindCommand tagCommand = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " t/" + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(new TagContainsKeywordsPredicate(keywords)), tagCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -9,7 +9,12 @@ import java.util.Arrays;
 import org.junit.Test;
 
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.model.person.AddressContainsKeywordsPredicate;
+import seedu.address.model.person.AnyContainsKeywordsPredicate;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+import seedu.address.model.tag.TagContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 
@@ -23,12 +28,40 @@ public class FindCommandParserTest {
     @Test
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
-        FindCommand expectedFindCommand =
+        FindCommand expectedGlobalFindCommand =
+                new FindCommand(new AnyContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+        assertParseSuccess(parser, "Alice Bob", expectedGlobalFindCommand);
+
+        FindCommand expectedNameFindCommand =
                 new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+        assertParseSuccess(parser, " n/Alice Bob", expectedNameFindCommand);
+
+        FindCommand expectedAddressFindCommand =
+                new FindCommand(new AddressContainsKeywordsPredicate(Arrays.asList("Serangoon", "Bishan")));
+        assertParseSuccess(parser, " a/Serangoon Bishan", expectedAddressFindCommand);
+
+        FindCommand expectedEmailFindCommand =
+                new FindCommand(new EmailContainsKeywordsPredicate(
+                        Arrays.asList("alice@example.com", "Bob@gmail.com")));
+        assertParseSuccess(parser, " e/alice@example.com Bob@gmail.com", expectedEmailFindCommand);
+
+        FindCommand expectedPhoneFindCommand =
+                new FindCommand(new PhoneContainsKeywordsPredicate(Arrays.asList("12345678", "98454632")));
+        assertParseSuccess(parser, " p/12345678 98454632", expectedPhoneFindCommand);
+
+        FindCommand expectedTagFindCommand =
+                new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList("friends", "enemy")));
+        assertParseSuccess(parser, " t/friends enemy", expectedTagFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedGlobalFindCommand);
+        assertParseSuccess(parser, " n/\n Alice \n \t Bob  \t", expectedNameFindCommand);
+        assertParseSuccess(parser, " a/\n Serangoon \n \t Bishan  \t", expectedAddressFindCommand);
+        assertParseSuccess(parser, " e/\n alice@example.com \n \t Bob@gmail.com  \t", expectedEmailFindCommand);
+        assertParseSuccess(parser, " p/\n 12345678 \n \t 98454632  \t", expectedPhoneFindCommand);
+        assertParseSuccess(parser, " t/\n friends \n \t enemy  \t", expectedTagFindCommand);
+
+
     }
 
 }

--- a/src/test/java/seedu/address/model/TagContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/TagContainsKeywordsPredicateTest.java
@@ -1,0 +1,82 @@
+package seedu.address.model;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import seedu.address.model.tag.TagContainsKeywordsPredicate;
+import seedu.address.testutil.PersonBuilder;
+
+public class TagContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        TagContainsKeywordsPredicate firstPredicate = new TagContainsKeywordsPredicate(firstPredicateKeywordList);
+        TagContainsKeywordsPredicate secondPredicate = new TagContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        TagContainsKeywordsPredicate firstPredicateCopy = new TagContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_tagContainsKeywords_returnsTrue() {
+        // One keyword
+        TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(Collections.singletonList("friends"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("friends").build()));
+
+        // Multiple keywords
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("friends", "family"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("friends", "family").build()));
+
+        // Only one matching keyword
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("friends", "enemy"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("friends", "family").build()));
+
+        // Mixed-case keywords
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("FRiEndS", "faMIlY"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("friends", "family").build()));
+
+        // Partial keywords
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("frie", "fami"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("friends", "family").build()));
+    }
+
+    @Test
+    public void test_tagDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withTags("friends").build()));
+
+        // Non-matching keyword
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("enemy"));
+        assertFalse(predicate.test(new PersonBuilder().withTags("friends", "family").build()));
+
+        // Keywords match phone, email, address and name, but does not match tag
+        predicate = new TagContainsKeywordsPredicate(
+                Arrays.asList("12345", "alice@email.com", "Alice", "Main", "Street"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
+                .withEmail("alice@email.com").withAddress("Main Street").withTags("friends").build()));
+    }
+}
+

--- a/src/test/java/seedu/address/model/person/AddressContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/AddressContainsKeywordsPredicateTest.java
@@ -1,0 +1,83 @@
+package seedu.address.model.person;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class AddressContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        AddressContainsKeywordsPredicate firstPredicate = new AddressContainsKeywordsPredicate(
+                firstPredicateKeywordList);
+        AddressContainsKeywordsPredicate secondPredicate = new AddressContainsKeywordsPredicate(
+                secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        AddressContainsKeywordsPredicate firstPredicateCopy = new AddressContainsKeywordsPredicate(
+                firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_addressContainsKeywords_returnsTrue() {
+        // One keyword
+        AddressContainsKeywordsPredicate predicate = new AddressContainsKeywordsPredicate(
+                Collections.singletonList("Serangoon"));
+        assertTrue(predicate.test(new PersonBuilder().withAddress("Serangoon Gardens").build()));
+
+        // Multiple keywords
+        predicate = new AddressContainsKeywordsPredicate(Arrays.asList("Serangoon", "Bishan"));
+        assertTrue(predicate.test(new PersonBuilder().withAddress("Serangoon Bishan").build()));
+
+        // Only one matching keyword
+        predicate = new AddressContainsKeywordsPredicate(Arrays.asList("Serangoon", "Tampines"));
+        assertTrue(predicate.test(new PersonBuilder().withAddress("Jurong Tampines").build()));
+
+        // Mixed-case keywords
+        predicate = new AddressContainsKeywordsPredicate(Arrays.asList("seRaNGooN", "BisHAN"));
+        assertTrue(predicate.test(new PersonBuilder().withAddress("Serangoon Bishan").build()));
+
+        // Partial keywords
+        predicate = new AddressContainsKeywordsPredicate(Arrays.asList("Seran", "Bish"));
+        assertTrue(predicate.test(new PersonBuilder().withAddress("Serangoon Bishan").build()));
+    }
+
+    @Test
+    public void test_addressDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        AddressContainsKeywordsPredicate predicate = new AddressContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withAddress("Serangoon").build()));
+
+        // Non-matching keyword
+        predicate = new AddressContainsKeywordsPredicate(Arrays.asList("Tampines"));
+        assertFalse(predicate.test(new PersonBuilder().withAddress("Serangoon Bishan").build()));
+
+        // Keywords match phone, email and name, but does not match address
+        predicate = new AddressContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Alice"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
+                .withEmail("alice@email.com").withAddress("Main Street").build()));
+    }
+}

--- a/src/test/java/seedu/address/model/person/AnyContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/AnyContainsKeywordsPredicateTest.java
@@ -1,0 +1,82 @@
+package seedu.address.model.person;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class AnyContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        AnyContainsKeywordsPredicate firstPredicate = new AnyContainsKeywordsPredicate(firstPredicateKeywordList);
+        AnyContainsKeywordsPredicate secondPredicate = new AnyContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        AnyContainsKeywordsPredicate firstPredicateCopy = new AnyContainsKeywordsPredicate(
+                firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_anyContainsKeywords_returnsTrue() {
+        // One keyword
+        AnyContainsKeywordsPredicate predicate = new AnyContainsKeywordsPredicate(
+                Collections.singletonList("12345678"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+
+        // Multiple keywords
+        predicate = new AnyContainsKeywordsPredicate(Arrays.asList("friends", "12345678"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("12345678").withTags("friends").build()));
+
+        // Only one matching keyword
+        predicate = new AnyContainsKeywordsPredicate(Arrays.asList("friends", "87654321"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("12345678").withTags("friends").build()));
+
+        // Mixed-case keywords
+        predicate = new AnyContainsKeywordsPredicate(Arrays.asList("FRiEndS", "AliCE"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice").withTags("friends", "family").build()));
+
+        // Partial keywords
+        predicate = new AnyContainsKeywordsPredicate(Arrays.asList("1234"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+    }
+
+    @Test
+    public void test_anyDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        AnyContainsKeywordsPredicate predicate = new AnyContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+
+        // Non-matching keyword
+        predicate = new AnyContainsKeywordsPredicate(Arrays.asList("97732443"));
+        assertFalse(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+
+        // Keywords do not match address, email, phone and name
+        predicate = new AnyContainsKeywordsPredicate(Arrays.asList("Side", "Ave", "bob@email.com", "987654321", "Bob"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345678")
+                .withEmail("alice@email.com").withAddress("Main Street").build()));
+    }
+}
+

--- a/src/test/java/seedu/address/model/person/EmailContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/EmailContainsKeywordsPredicateTest.java
@@ -1,0 +1,79 @@
+package seedu.address.model.person;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class EmailContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        EmailContainsKeywordsPredicate firstPredicate = new EmailContainsKeywordsPredicate(
+                firstPredicateKeywordList);
+        EmailContainsKeywordsPredicate secondPredicate = new EmailContainsKeywordsPredicate(
+                secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        EmailContainsKeywordsPredicate firstPredicateCopy = new EmailContainsKeywordsPredicate(
+                firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_emailContainsKeywords_returnsTrue() {
+        // One keyword
+        EmailContainsKeywordsPredicate predicate = new EmailContainsKeywordsPredicate(
+                Collections.singletonList("alice@example.com"));
+        assertTrue(predicate.test(new PersonBuilder().withEmail("alice@example.com").build()));
+
+        // Multiple keywords, but only one matching
+        predicate = new EmailContainsKeywordsPredicate(Arrays.asList("alice@example.com", "bob@gmail.com"));
+        assertTrue(predicate.test(new PersonBuilder().withEmail("alice@example.com").build()));
+
+        // Mixed-case keywords
+        predicate = new EmailContainsKeywordsPredicate(Arrays.asList("aLiCE@ExampLE.com"));
+        assertTrue(predicate.test(new PersonBuilder().withEmail("alice@example.com").build()));
+
+        // Partial keywords
+        predicate = new EmailContainsKeywordsPredicate(Arrays.asList("@example.com"));
+        assertTrue(predicate.test(new PersonBuilder().withEmail("alice@example.com").build()));
+    }
+
+    @Test
+    public void test_emailDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        EmailContainsKeywordsPredicate predicate = new EmailContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withEmail("alice@example.com").build()));
+
+        // Non-matching keyword
+        predicate = new EmailContainsKeywordsPredicate(Arrays.asList("carol@yahoo.com"));
+        assertFalse(predicate.test(new PersonBuilder().withEmail("alice@example.com").build()));
+
+        // Keywords match phone, name and address, but does not match email
+        predicate = new EmailContainsKeywordsPredicate(Arrays.asList("12345", "Alice", "Main", "Street"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
+                .withEmail("al1ce@example.com").withAddress("Main Street").build()));
+    }
+}

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -55,6 +55,10 @@ public class NameContainsKeywordsPredicateTest {
         // Mixed-case keywords
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("aLIce", "bOB"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+
+        // Partial keywords
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Ali", "Bo"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PhoneContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneContainsKeywordsPredicateTest.java
@@ -1,0 +1,73 @@
+package seedu.address.model.person;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class PhoneContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        PhoneContainsKeywordsPredicate firstPredicate = new PhoneContainsKeywordsPredicate(firstPredicateKeywordList);
+        PhoneContainsKeywordsPredicate secondPredicate = new PhoneContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        PhoneContainsKeywordsPredicate firstPredicateCopy = new PhoneContainsKeywordsPredicate(
+                firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_phoneContainsKeywords_returnsTrue() {
+        // One keyword
+        PhoneContainsKeywordsPredicate predicate = new PhoneContainsKeywordsPredicate(
+                Collections.singletonList("12345678"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+
+        // Multiple keywords, but only one matching
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("12345678", "92234556"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+
+        // Partial keywords
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("1234"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+    }
+
+    @Test
+    public void test_phoneDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        PhoneContainsKeywordsPredicate predicate = new PhoneContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+
+        // Non-matching keyword
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("97732443"));
+        assertFalse(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+
+        // Keywords match address, email and name, but does not match phone
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("Main", "Street", "alice@email.com", "Alice"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345678")
+                .withEmail("alice@email.com").withAddress("Main Street").build()));
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -33,7 +33,7 @@ public class TypicalPersons {
             .withEmail("johnd@example.com").withPhone("98765432")
             .withTags("owesMoney", "friends").build();
     public static final ReadOnlyPerson CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withAddress("wall street").build();
+            .withEmail("heinz@example.com").withAddress("wall street").withTags("enemy").build();
     public static final ReadOnlyPerson DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withAddress("10th street").build();
     public static final ReadOnlyPerson ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -127,7 +127,7 @@ public abstract class AddressBookSystemTest {
      * Displays all persons with any parts of their names matching {@code keyword} (case-insensitive).
      */
     protected void showPersonsWithName(String keyword) {
-        executeCommand(FindCommand.COMMAND_WORD + " " + keyword);
+        executeCommand(FindCommand.COMMAND_WORD + " n/" + keyword);
         assert getModel().getFilteredPersonList().size() < getModel().getAddressBook().getPersonList().size();
     }
 

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -1,10 +1,12 @@
 package systemtests;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.DANIEL;
+import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.KEYWORD_MATCHING_MEIER;
 
 import java.util.ArrayList;
@@ -110,24 +112,28 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
-        /* Case: find phone number of person in address book -> 0 persons found */
+        /* Case: find phone number of person in address book -> 1 person found */
         command = FindCommand.COMMAND_WORD + " " + DANIEL.getPhone().value;
+        ModelHelper.setFilteredList(expectedModel, DANIEL);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
-        /* Case: find address of person in address book -> 0 persons found */
-        command = FindCommand.COMMAND_WORD + " " + DANIEL.getAddress().value;
+        /* Case: find address of person in address book -> 1 person found */
+        command = FindCommand.COMMAND_WORD + " " + FIONA.getAddress().value;
+        ModelHelper.setFilteredList(expectedModel, FIONA);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
-        /* Case: find email of person in address book -> 0 persons found */
+        /* Case: find email of person in address book -> 1 person found */
         command = FindCommand.COMMAND_WORD + " " + DANIEL.getEmail().value;
+        ModelHelper.setFilteredList(expectedModel, DANIEL);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
-        /* Case: find tags of person in address book -> 0 persons found */
-        List<Tag> tags = new ArrayList<>(DANIEL.getTags());
+        /* Case: find tags of person in address book -> 1 person found */
+        List<Tag> tags = new ArrayList<>(CARL.getTags());
         command = FindCommand.COMMAND_WORD + " " + tags.get(0).tagName;
+        ModelHelper.setFilteredList(expectedModel, CARL);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
@@ -152,6 +158,11 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         /* Case: mixed case command word -> rejected */
         command = "FiNd Meier";
         assertCommandFailure(command, MESSAGE_UNKNOWN_COMMAND);
+
+        /* Case: more than a single prefix -> rejected */
+        command = "find n/Meier t/friends";
+        String message = String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE);
+        assertCommandFailure(command, message);
     }
 
     /**

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -94,13 +94,12 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
-        /* Case: find person in address book, keyword is substring of name -> 0 persons found */
+        /* Case: find person in address book, keyword is substring of name -> 1 person found */
         command = FindCommand.COMMAND_WORD + " Mei";
-        ModelHelper.setFilteredList(expectedModel);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
-        /* Case: find person in address book, name is substring of keyword -> 0 persons found */
+        /* Case: find person in address book, name is substring of keyword -> 0 person found */
         command = FindCommand.COMMAND_WORD + " Meiers";
         ModelHelper.setFilteredList(expectedModel);
         assertCommandSuccess(command, expectedModel);


### PR DESCRIPTION
Referencing issues #21 , #22 , #23 , #25 .

I have implemented an enhanced `find` command and created/updated the relevant tests and documentation. 

In summary, the enhanced `find` command can be understood as:
- `find` without any stated prefix will search for matching strings/substrings in all details (including name, address, email, phone, and tags) -- in a sense, like a 'global search'
- `find n/[KEYWORDS]` will search for matching strings/substrings in names -- a search confined to names only
- `find a/[KEYWORDS]` will search for matching strings/substrings in addresses -- a search confined to addresses only
- `find e/[KEYWORDS]` will search for matching strings/substrings in emails -- a search confined to emails only
- `find p/[KEYWORDS]` will search for matching strings/substrings in phone numbers -- a search confined to phone numbers only
- `find t/[KEYWORDS] will search for matching strings/substrings in names -- a search confined to tags only

I was considering either extending the `FindCommand` to have five new subclasses for each type of confined search, or simply adapting the current `FindCommand` and `FindCommandParser` to work this out. In the end, I decided on the latter approach because I saw parallels between such an implementation and the `AddCommand`, which would allow me to make use of existing resources such as the `ArgumentTokenizer` and prevent the need to implement an entirely new command (or rather, five new commands).

P/S Not sure if it is fine to have so many changes in a single pull request, but I did try to group related changes into a single commit, and felt that it might be better to ensure that the full solution was implemented for this particular feature before opening a pull request...