### PR TITLE
Start GraphStream viewer only when there is a display

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -44,7 +44,11 @@ public class LogicManager extends ComponentManager implements Logic {
         this.undoRedoStack = new UndoRedoStack();
         this.graphWrapper = new GraphWrapper();
         graphWrapper.buildGraph(model);
-        graphViewer = graphWrapper.display();
+        if (System.getProperty("testfx.headless") == null) {
+            graphViewer = graphWrapper.display();
+        } else {
+            graphViewer = null;
+        }
     }
 
     @Override


### PR DESCRIPTION
Added a check to not start the viewer when we are in a headless environment. This should make our tests pass again!

Resolves #91.